### PR TITLE
error handling fix

### DIFF
--- a/src/test/java/io/temporal/samples/dsl/DslActivityTest.java
+++ b/src/test/java/io/temporal/samples/dsl/DslActivityTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
 import io.temporal.common.RetryOptions;
 import io.temporal.samples.dsl.models.DslWorkflow;
 import io.temporal.samples.hello.HelloActivity;
@@ -109,6 +110,8 @@ public class DslActivityTest {
 
     // trigger signal
     workflow.callback("SampleActivities1");
+    // Wait for workflow to complete
+    WorkflowStub.fromTyped(workflow).getResult(Void.class);
   }
 
   /*


### PR DESCRIPTION
I see cancellation working fine. But the code that catches activity exception mishandles it. 

After this fixes the test fails with:
```
Caused by: io.temporal.common.converter.DataConverterException: com.fasterxml.jackson.databind.JsonMappingException: Infinite recursion (StackOverflowError) (through reference chain: com.fasterxml.jackson.databind.MappingJsonFactory["_objectCodec"]->com.fasterxml.jackson.databind.ObjectMapper["_jsonFactory"]->com.fasterxml.jackson.databind.MappingJsonFactory["_objectCodec"]->com.fasterxml.jackson.databind.ObjectMapper["_jsonFactory"]->com.fasterxml.jackson.databind.MappingJsonFactory["_objectCodec"]->com.fasterxml.jackson.databind.ObjectMapper["_jsonFactory"]->com.fasterxml.jackson.databind.MappingJsonFactory["_objectCodec"]->com.fasterxml.jackson.databind.ObjectMapper["_jsonFactory"]->com.fasterxml.jackson.databind.MappingJsonFactory["_objectCodec"]->com.fasterxml.jackson.databind.ObjectMapper["_jsonFactory"]->com.fasterxml.jackson.databind.MappingJsonFactory["_objectCodec"]->com.fasterxml.jackson.databind.ObjectMapper["_jsonFactory"]->com.fasterxml.jackson.databind.MappingJsonFactory["_objectCodec"]->com.fasterxml.jackson.databind.ObjectMapper["_jsonFactory"]->com.fasterxml.jackson.databind
```
I'm not sure what type of object goes through the mapper.